### PR TITLE
Implement notebook status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '0.12'
+  - '5.0.0'
 sudo: false
 env:
   matrix:

--- a/example/index.css
+++ b/example/index.css
@@ -68,6 +68,21 @@
 }
 
 
+.jp-FileBrowser-nb-icon:before {
+  content: "\f02d";
+}
+
+
+.jp-FileBrowser-nb-icon.jp-mod-success:before {
+  color: #27AE60;
+}
+
+
+.jp-FileBrowser-nb-icon.jp-mod-error:before {
+  color: #E74C3C;
+}
+
+
 .jp-EditorWidget {
   min-height: 200px;
 }

--- a/example/package.json
+++ b/example/package.json
@@ -7,20 +7,19 @@
     "codemirror": "^5.9.0",
     "jupyter-js-editor": "jupyter/jupyter-js-editor",
     "jupyter-js-filebrowser": "file:..",
+    "jupyter-js-services": "file:../node_modules/jupyter-js-services",
     "phosphor-splitpanel": "^1.0.0-beta.2",
-    "phosphor-widget": "1.0.0-beta.6",
-    "steal": "^0.12.7"
+    "phosphor-widget": "1.0.0-beta.6"
   },
   "devDependencies": {
-    "jupyter-js-services": "^0.2.2",
     "rimraf": "^2.4.4",
+    "steal": "^0.12.7",
     "typescript": "^1.7.3"
   },
   "scripts": {
     "build": "tsc",
     "clean": "rimraf *.js",
     "postinstall": "npm dedupe",
-    "prepublish": "npm run build",
     "update": "npm install jupyter-js-filebrowser --force"
   },
   "system": {

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
     "codemirror": "^5.9.0",
     "jupyter-js-editor": "jupyter/jupyter-js-editor",
     "jupyter-js-filebrowser": "file:..",
-    "jupyter-js-services": "file:../node_modules/jupyter-js-services",
+    "jupyter-js-services": "blink1073/jupyter-js-services#452b03c",
     "phosphor-splitpanel": "^1.0.0-beta.2",
     "phosphor-widget": "1.0.0-beta.6"
   },

--- a/package.json
+++ b/package.json
@@ -5,16 +5,18 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "jupyter-js-services": "^0.2.2",
+    "jupyter-js-services": "blink1073/jupyter-js-services#452b03c",
     "moment": "^2.10.6",
     "phosphor-command": "^0.5.0",
     "phosphor-dialog": "blink1073/phosphor-dialog#f5afb2b",
+    "phosphor-disposable": "^1.0.5",
     "phosphor-domutil": "^1.2.0",
     "phosphor-dragdrop": "^0.9.0",
     "phosphor-menus": "1.0.0-beta.3",
     "phosphor-messaging": "^1.0.5",
     "phosphor-nodewrapper": "^1.0.4",
     "phosphor-properties": "^2.0.0",
+    "phosphor-signaling": "^1.2.0",
     "phosphor-widget": "1.0.0-beta.6"
   },
   "devDependencies": {

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -13,4 +13,5 @@ npm run docs
 cd example
 npm install
 npm run clean
+npm dedupe
 npm run build

--- a/src/FileBrowserWidget.ts
+++ b/src/FileBrowserWidget.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import {
-  IContentsModel
+  IContentsModel, KernelStatus
 } from 'jupyter-js-services';
 
 import * as moment from 'moment';
@@ -155,6 +155,21 @@ const FOLDER_ICON_CLASS = 'jp-FileBrowser-folder-icon';
  * The class name added to a file icon.
  */
 const FILE_ICON_CLASS = 'jp-FileBrowser-file-icon';
+
+/**
+ * The class name added to a notebook icon.
+ */
+const NOTEBOOK_ICON_CLASS = 'jp-FileBrowser-nb-icon';
+
+/**
+ * The class name added to indicate success.
+ */
+const SUCCESS_CLASS = 'jp-mod-success';
+
+/**
+ * The class name added to indicated error.
+ */
+const ERROR_CLASS = 'jp-mod-error';
 
 
 /**
@@ -402,6 +417,19 @@ class FileBrowserWidget extends Widget {
 
     // Update the breadcrumb list.
     updateCrumbs(this._crumbs, this._crumbSeps, this._model.path);
+
+    // Handle notebook session statuses.
+    let paths = this._model.items.map(item => item.path);
+    for (let session of this._model.sessions) {
+      let index = paths.indexOf(session.notebookPath);
+      let node = this._items[index].firstChild as HTMLElement;
+      if (session.status === KernelStatus.Idle || session.status === KernelStatus.Idle) {
+        node.classList.add(SUCCESS_CLASS);
+      } else {
+        node.firstElementChild.classList.add(ERROR_CLASS);
+      }
+      node.title = session.kernel.name;
+    }
   }
 
   /**
@@ -918,6 +946,8 @@ function createItemNode(): HTMLElement {
 function createIconClass(item: IContentsModel): string {
   if (item.type === 'directory') {
     return ROW_ICON_CLASS + ' ' + FOLDER_ICON_CLASS;
+  } else if (item.type === 'notebook') {
+    return ROW_ICON_CLASS + ' ' + NOTEBOOK_ICON_CLASS;
   } else {
     return ROW_ICON_CLASS + ' ' + FILE_ICON_CLASS;
   }


### PR DESCRIPTION
Fixes #20.  Relies on https://github.com/jupyter/jupyter-js-services/pull/62.
Adds notebook icons with kernel status indicator and kernel name title.

<img width="687" alt="screen shot 2015-12-21 at 4 12 04 pm" src="https://cloud.githubusercontent.com/assets/2096628/11942674/c72954d8-a7fd-11e5-96ee-80ec3844308a.png">
