### PR TITLE
Update styling of file listing

### DIFF
--- a/example/index.css
+++ b/example/index.css
@@ -10,31 +10,63 @@
 }
 
 
-.jp-FileBrowser-item-edit {
-  z-index: 10000;
+.jp-FileBrowser-breadcrumb-item {
+  margin-right: 5px;
+  border: 1px solid transparent;
 }
 
 
-.jp-FileBrowser-item-spacer {
-}
-
-.jp-FileBrowser-item-modified {
-  overflow: hidden;
-  white-space: nowrap;
-  text-align: right;
-  padding-right: 5px;
-  min-width: 70px;
+.jp-FileBrowser-button {
+  border-bottom: 1px solid #757575;
+  padding-left: 3px;
+  padding-bottom: 8px;
 }
 
 
 .jp-FileBrowser-button-item {
-  display: flex;
   background-color: #FAFAFA;
   font-size: 16px;
   border: 1px solid #757575;
   height: 30px;
   border-radius: 3px;
+  margin-right: 3px;
   max-width: 100px;
+}
+
+
+.jp-FileBrowser-row {
+  padding: 4px 8px;
+  border: 1px solid transparent;
+}
+
+
+.jp-FileBrowser-row-file {
+  padding-top: 4px;
+  padding-bottom: 4px;
+  min-width: 200px;
+}
+
+
+.jp-FileBrowser-item-icon {
+  width: 21px;
+  padding-left: 2px;
+  padding-right: 2px;
+}
+
+
+.jp-FileBrowser-item-text {
+  position: absolute;
+  left: 21px;
+  right: 21px;
+  padding-left: 2px;
+}
+
+
+.jp-FileBrowser-item-modified {
+  padding-right: 5px;
+  width: 70px;
+  padding-top: 4px;
+  padding-bottom: 4px;
 }
 
 
@@ -60,7 +92,7 @@
 
 
 .jp-FileBrowser-list-area {
-  border-top: 1px solid #757575;
+
 }
 
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -132,12 +132,14 @@ function main(): void {
   });
 
 
+  /*
   fileBrowser.node.addEventListener('contextmenu', (event: MouseEvent) => {
     event.preventDefault();
     let x = event.clientX;
     let y = event.clientY;
     contextMenu.popup(x, y);
   });
+*/
 
 
   window.onresize = () => panel.update();

--- a/lib/index.css
+++ b/lib/index.css
@@ -11,13 +11,6 @@
 
 .jp-FileBrowser-breadcrumbs {
   flex: 0 0 auto;
-  padding: 5px;
-}
-
-
-.jp-FileBrowser-breadcrumb-item {
-  margin-right: 5px;
-  border: 1px solid transparent;
 }
 
 
@@ -48,7 +41,6 @@
   align-items: center;
   justify-content: center;
   margin: 0;
-  padding-left: 3px;
 }
 
 
@@ -56,7 +48,6 @@
   flex: 1 1 auto;
   text-align: center;
   vertical-align: middle;
-  margin-right: 3px;
 }
 
 
@@ -66,26 +57,9 @@
 }
 
 
-.jp-FileBrowser-header {
-  flex: 0 0 auto;
-  display: flex;
-  flex-direction: row;
-  padding: 5px;
-}
-
-
-.jp-FileBrowser-header-file {
-  flex: 1 1 auto;
-}
-
-
-.jp-FileBrowser-header-modified {
-  flex: 0 0 auto;
-}
-
 .jp-FileBrowser-list-container {
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
   flex: 1 1 auto;
 }
 
@@ -100,34 +74,38 @@
 }
 
 
+.jp-FileBrowser-item-edit {
+  z-index: 10000;
+}
+
+
 .jp-FileBrowser-row {
   display: table-row;
-  padding: 4px 8px;
-  border: 1px solid transparent;
+  position: relative;
 }
 
 
-.jp-FileBrowser-row > span {
+.jp-FileBrowser-row-file {
   display: table-cell;
-  padding-top: 4px;
-  padding-bottom: 4px;
+  position: relative;
 }
-
 
 
 .jp-FileBrowser-item-icon {
-  width: 21px;
-  padding-left: 2px;
-  padding-right: 2px;
   text-align: center;
 }
-
 
 
 .jp-FileBrowser-item-text {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  padding-left: 2px;
-  padding-right: 35px;
+}
+
+
+.jp-FileBrowser-item-modified {
+  display: table-cell;
+  overflow: hidden;
+  white-space: nowrap;
+  text-align: right;
 }

--- a/src/FileBrowserWidget.ts
+++ b/src/FileBrowserWidget.ts
@@ -77,21 +77,6 @@ const BUTTON_ICON_CLASS = 'jp-FileBrowser-button-icon';
 const UPLOAD_CLASS = 'jp-FileBrowser-upload';
 
 /**
- * The class name added to the header node.
- */
-const HEADER_CLASS = 'jp-FileBrowser-header';
-
-/**
- * The class name added to the header file node.
- */
-const HEADER_FILE_CLASS = 'jp-FileBrowser-header-file';
-
-/**
- * The class name added to the header modified node.
- */
-const HEADER_MOD_CLASS = 'jp-FileBrowser-header-modified';
-
-/**
  * The class name added to the breadcrumb node.
  */
 const BREADCRUMB_CLASS = 'jp-FileBrowser-breadcrumbs';
@@ -112,9 +97,29 @@ const LIST_CONTAINER_CLASS = 'jp-FileBrowser-list-container';
 const LIST_AREA_CLASS = 'jp-FileBrowser-list-area';
 
 /**
+ * The class name added to the header node.
+ */
+const HEADER_CLASS = 'jp-FileBrowser-header';
+
+/**
+ * The class name added to the header file node.
+ */
+const HEADER_FILE_CLASS = 'jp-FileBrowser-header-file';
+
+/**
+ * The class name added to the header modified node.
+ */
+const HEADER_MOD_CLASS = 'jp-FileBrowser-header-modified';
+
+/**
  * The class name added to FileBrowser rows.
  */
 const ROW_CLASS = 'jp-FileBrowser-row';
+
+/**
+ * The class name added to FileBrowser row file divs.
+ */
+const ROW_FILE_CLASS = 'jp-FileBrowser-row-file';
 
 /**
  * The class name added to selected rows.
@@ -235,21 +240,10 @@ class FileBrowserWidget extends Widget {
     let buttonBar = document.createElement('div');
     buttonBar.className = BUTTON_CLASS;
 
-    // Create the header.
-    let header = document.createElement('div');
-    header.classList.add(HEADER_CLASS);
-    let fileName = document.createElement('span');
-    fileName.textContent = 'File Name';
-    fileName.className = HEADER_FILE_CLASS;
-    let modified = document.createElement('span');
-    modified.textContent = 'Last Modified';
-    modified.className = HEADER_MOD_CLASS;
-    header.appendChild(fileName);
-    header.appendChild(modified);
-
     // Create the file list.
     let wrapper = document.createElement('div');
     wrapper.className = LIST_CONTAINER_CLASS;
+
     let list = document.createElement('ul');
     list.classList.add(LIST_AREA_CLASS);
     wrapper.appendChild(list);
@@ -257,7 +251,6 @@ class FileBrowserWidget extends Widget {
     // Add the children.
     node.appendChild(breadcrumbs);
     node.appendChild(buttonBar);
-    node.appendChild(header);
     node.appendChild(wrapper);
     return node;
   }
@@ -584,9 +577,9 @@ class FileBrowserWidget extends Widget {
     let paths = this._model.items.map(item => item.path);
     for (let sessionId of this._model.sessionIds) {
       let index = paths.indexOf(sessionId.notebook.path);
-      let node = this._items[index].firstChild as HTMLElement;
+      let node = this._items[index].getElementsByClassName(FILE_ICON_CLASS)[0];
       node.classList.add(RUNNING_CLASS);
-      node.title = sessionId.kernel.name;
+      (node as HTMLElement).title = sessionId.kernel.name;
     }
     if (this._model.sessionIds.length) {
       this.node.classList.add(RUNNING_CLASS);
@@ -1169,14 +1162,17 @@ enum Button {
 function createItemNode(): HTMLElement {
   let node = document.createElement('li');
   node.className = ROW_CLASS;
+  let fnode = document.createElement('div');
+  fnode.className = ROW_FILE_CLASS;
   let inode = document.createElement('span');
   inode.className = ROW_ICON_CLASS;
   let tnode = document.createElement('span');
   tnode.className = ROW_TEXT_CLASS;
   let mnode = document.createElement('span');
   mnode.className = ROW_TIME_CLASS;
-  node.appendChild(inode);
-  node.appendChild(tnode);
+  fnode.appendChild(inode);
+  fnode.appendChild(tnode);
+  node.appendChild(fnode);
   node.appendChild(mnode);
   return node;
 }
@@ -1220,8 +1216,8 @@ function createModifiedContent(item: IContentsModel): string {
  * Update the node state for an IContentsModel.
  */
 function updateItemNode(item: IContentsModel, node: HTMLElement): void {
-  let icon = node.firstChild as HTMLElement;
-  let text = node.children[1] as HTMLElement;
+  let icon = node.firstChild.firstChild as HTMLElement;
+  let text = (node.firstChild as HTMLElement).children[1] as HTMLElement;
   let modified = node.lastChild as HTMLElement;
   icon.className = createIconClass(item);
   text.textContent = createTextContent(item);

--- a/src/index.css
+++ b/src/index.css
@@ -11,13 +11,6 @@
 
 .jp-FileBrowser-breadcrumbs {
   flex: 0 0 auto;
-  padding: 5px;
-}
-
-
-.jp-FileBrowser-breadcrumb-item {
-  margin-right: 5px;
-  border: 1px solid transparent;
 }
 
 
@@ -48,7 +41,6 @@
   align-items: center;
   justify-content: center;
   margin: 0;
-  padding-left: 3px;
 }
 
 
@@ -56,7 +48,6 @@
   flex: 1 1 auto;
   text-align: center;
   vertical-align: middle;
-  margin-right: 3px;
 }
 
 
@@ -66,26 +57,9 @@
 }
 
 
-.jp-FileBrowser-header {
-  flex: 0 0 auto;
-  display: flex;
-  flex-direction: row;
-  padding: 5px;
-}
-
-
-.jp-FileBrowser-header-file {
-  flex: 1 1 auto;
-}
-
-
-.jp-FileBrowser-header-modified {
-  flex: 0 0 auto;
-}
-
 .jp-FileBrowser-list-container {
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
   flex: 1 1 auto;
 }
 
@@ -100,34 +74,38 @@
 }
 
 
+.jp-FileBrowser-item-edit {
+  z-index: 10000;
+}
+
+
 .jp-FileBrowser-row {
   display: table-row;
-  padding: 4px 8px;
-  border: 1px solid transparent;
+  position: relative;
 }
 
 
-.jp-FileBrowser-row > span {
+.jp-FileBrowser-row-file {
   display: table-cell;
-  padding-top: 4px;
-  padding-bottom: 4px;
+  position: relative;
 }
-
 
 
 .jp-FileBrowser-item-icon {
-  width: 21px;
-  padding-left: 2px;
-  padding-right: 2px;
   text-align: center;
 }
-
 
 
 .jp-FileBrowser-item-text {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  padding-left: 2px;
-  padding-right: 35px;
+}
+
+
+.jp-FileBrowser-item-modified {
+  display: table-cell;
+  overflow: hidden;
+  white-space: nowrap;
+  text-align: right;
 }


### PR DESCRIPTION
Cleans up resizing and scrolling behavior of the file listing area.
Table headings in CSS have serious limitations that led to removing the `File` and `Last Modified` headers, since the columns are self explanatory.
Once we have a phosphor-grid, we can swap that out and add advanced features like sorting and filtering.

![filebrowser_scrolling](https://cloud.githubusercontent.com/assets/2096628/12060509/fad5128c-af36-11e5-9a3a-f267a19b52e3.gif)
