### PR TITLE
[WIP] Add cut/copy/paste event handlers

### DIFF
--- a/src/listing.ts
+++ b/src/listing.ts
@@ -210,7 +210,7 @@ class DirListing extends Widget {
     node.appendChild(header);
     node.appendChild(body);
     body.appendChild(contents);
-    node.tabIndex = 1;
+    contents.tabIndex = 0;
     return node;
   }
 
@@ -467,7 +467,6 @@ class DirListing extends Widget {
    * not be called directly by user code.
    */
   handleEvent(event: Event): void {
-    console.log(event.type);
     switch (event.type) {
     case 'mousedown':
       this._evtMousedown(event as MouseEvent);
@@ -828,7 +827,7 @@ class DirListing extends Widget {
    * Handle the `'copy'` event for the widget.
    */
   private _evtCopy(event: ClipboardEvent): void {
-    if (!this.node.contains(event.target as HTMLElement) &&
+    if (event.target === this._editNode ||
         !this.node.contains(document.activeElement as HTMLElement)) {
       return;
     }
@@ -841,7 +840,7 @@ class DirListing extends Widget {
    * Handle the `'cut'` event for the widget.
    */
   private _evtCut(event: ClipboardEvent): void {
-    if (!this.node.contains(event.target as HTMLElement) &&
+    if (event.target === this._editNode ||
         !this.node.contains(document.activeElement as HTMLElement)) {
       return;
     }
@@ -854,7 +853,7 @@ class DirListing extends Widget {
    * Handle the `'paste'` event for the widget.
    */
   private _evtPaste(event: ClipboardEvent): void {
-    if (!this.node.contains(event.target as HTMLElement) &&
+    if (event.target === this._editNode ||
         !this.node.contains(document.activeElement as HTMLElement)) {
       return;
     }

--- a/src/listing.ts
+++ b/src/listing.ts
@@ -467,6 +467,7 @@ class DirListing extends Widget {
    * not be called directly by user code.
    */
   handleEvent(event: Event): void {
+    console.log(event.type);
     switch (event.type) {
     case 'mousedown':
       this._evtMousedown(event as MouseEvent);
@@ -488,6 +489,15 @@ class DirListing extends Widget {
       break;
     case 'scroll':
       this._evtScroll(event as MouseEvent);
+      break;
+    case 'copy':
+      this._evtCopy(event as ClipboardEvent);
+      break;
+    case 'cut':
+      this._evtCut(event as ClipboardEvent);
+      break;
+    case 'paste':
+      this._evtPaste(event as ClipboardEvent);
       break;
     case 'p-dragenter':
       this._evtDragEnter(event as IDragEvent);
@@ -516,6 +526,9 @@ class DirListing extends Widget {
     node.addEventListener('click', this);
     node.addEventListener('dblclick', this);
     list.addEventListener('scroll', this);
+    document.addEventListener('copy', this);
+    document.addEventListener('cut', this);
+    document.addEventListener('paste', this);
     node.addEventListener('p-dragenter', this);
     node.addEventListener('p-dragleave', this);
     node.addEventListener('p-dragover', this);
@@ -534,6 +547,9 @@ class DirListing extends Widget {
     node.removeEventListener('click', this);
     node.removeEventListener('dblclick', this);
     list.removeEventListener('scroll', this);
+    document.removeEventListener('copy', this);
+    document.removeEventListener('cut', this);
+    document.removeEventListener('paste', this);
     node.removeEventListener('p-dragenter', this);
     node.removeEventListener('p-dragleave', this);
     node.removeEventListener('p-dragover', this);
@@ -805,6 +821,47 @@ class DirListing extends Widget {
 
       }
       node = node.parentElement;
+    }
+  }
+
+  /**
+   * Handle the `'copy'` event for the widget.
+   */
+  private _evtCopy(event: ClipboardEvent): void {
+    if (!this.node.contains(event.target as HTMLElement) &&
+        !this.node.contains(document.activeElement as HTMLElement)) {
+      return;
+    }
+    this.copy();
+    event.stopPropagation();
+    event.preventDefault();
+  }
+
+  /**
+   * Handle the `'cut'` event for the widget.
+   */
+  private _evtCut(event: ClipboardEvent): void {
+    if (!this.node.contains(event.target as HTMLElement) &&
+        !this.node.contains(document.activeElement as HTMLElement)) {
+      return;
+    }
+    this.cut();
+    event.stopPropagation();
+    event.preventDefault();
+  }
+
+  /**
+   * Handle the `'paste'` event for the widget.
+   */
+  private _evtPaste(event: ClipboardEvent): void {
+    if (!this.node.contains(event.target as HTMLElement) &&
+        !this.node.contains(document.activeElement as HTMLElement)) {
+      return;
+    }
+    if (this._clipboard.length) {
+      this.paste();
+      event.stopPropagation();
+      event.preventDefault();
     }
   }
 

--- a/src/listing.ts
+++ b/src/listing.ts
@@ -262,6 +262,13 @@ class DirListing extends Widget {
   }
 
   /**
+   * Get the contents node for the listing.
+   */
+  get contentsNode(): HTMLElement {
+    return utils.findElement(this.node, LIST_AREA_CLASS);
+  }
+
+  /**
    * Get the open requested signal.
    */
   get openRequested(): ISignal<DirListing, IContentsModel> {
@@ -564,7 +571,7 @@ class DirListing extends Widget {
     // Fetch common variables.
     let items = this._model.items;
     let nodes = this._items;
-    let content = utils.findElement(this.node, LIST_AREA_CLASS);
+    let content = this.contentsNode;
     let subtype = this.constructor as typeof DirListing;
 
     // Remove any excess item nodes.
@@ -827,8 +834,7 @@ class DirListing extends Widget {
    * Handle the `'copy'` event for the widget.
    */
   private _evtCopy(event: ClipboardEvent): void {
-    if (event.target === this._editNode ||
-        !this.node.contains(document.activeElement as HTMLElement)) {
+    if (document.activeElement !== this.contentsNode) {
       return;
     }
     this.copy();
@@ -840,8 +846,7 @@ class DirListing extends Widget {
    * Handle the `'cut'` event for the widget.
    */
   private _evtCut(event: ClipboardEvent): void {
-    if (event.target === this._editNode ||
-        !this.node.contains(document.activeElement as HTMLElement)) {
+    if (document.activeElement !== this.contentsNode) {
       return;
     }
     this.cut();
@@ -853,8 +858,7 @@ class DirListing extends Widget {
    * Handle the `'paste'` event for the widget.
    */
   private _evtPaste(event: ClipboardEvent): void {
-    if (event.target === this._editNode ||
-        !this.node.contains(document.activeElement as HTMLElement)) {
+    if (document.activeElement !== this.contentsNode) {
       return;
     }
     if (this._clipboard.length) {
@@ -1113,7 +1117,7 @@ class DirListing extends Widget {
    * Allow the user to rename item on a given row.
    */
   private _doRename(): Promise<string> {
-    let listing = utils.findElement(this.node, LIST_AREA_CLASS);
+    let listing = this.contentsNode;
     let row = utils.findElement(listing, SELECTED_CLASS);
     let fileCell = utils.findElement(row, ITEM_FILE_CLASS);
     let text = utils.findElement(row, ITEM_TEXT_CLASS);


### PR DESCRIPTION
- Use the system clipboard for cut/copy/paste
- For actions, use the new `generateClipboardEvent` function in `jupyter-js-domutils`: https://github.com/jupyter/jupyter-js-domutils/pull/7
