### PR TITLE
Cleanup rename and add Soft Selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-js-filebrowser",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "File browser widget for Jupyter",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/listing.ts
+++ b/src/listing.ts
@@ -451,7 +451,8 @@ class DirListing extends Widget {
     for (let item of items) {
       if (!this._softSelection && !this._model.isSelected(item.name)) {
         continue;
-      } else if (this._softSelection !== item.name) {
+      }
+      if (this._softSelection !== item.name) {
         continue;
       }
       if (item.type !== 'directory') {
@@ -472,7 +473,8 @@ class DirListing extends Widget {
     for (let item of items) {
       if (!this._softSelection && !this._model.isSelected(item.name)) {
         continue;
-      } else if (this._softSelection !== item.name) {
+      }
+      if (this._softSelection !== item.name) {
         continue;
       }
       if (item.type !== 'directory') {
@@ -976,7 +978,8 @@ class DirListing extends Widget {
     for (let item of items) {
       if (!this._softSelection && !this._model.isSelected(item.name)) {
         continue;
-      } else if (this._softSelection !== item.name) {
+      }
+      if (this._softSelection !== item.name) {
         continue;
       }
       var name = item.name;
@@ -1142,7 +1145,10 @@ class DirListing extends Widget {
     this._clipboard = []
     let items = this._model.sortedItems;
     for (var item of items) {
-      if (!this._model.isSelected(item.name)) {
+      if (!this._softSelection && !this._model.isSelected(item.name)) {
+        continue;
+      }
+      if (this._softSelection !== item.name) {
         continue;
       }
       let row = arrays.find(this._items, row => {

--- a/src/listing.ts
+++ b/src/listing.ts
@@ -1147,6 +1147,10 @@ class DirListing extends Widget {
     let text = utils.findElement(row, ITEM_TEXT_CLASS);
     let original = text.textContent;
 
+    if (!fileCell) {
+      return;
+    }
+
     return Private.doRename(fileCell as HTMLElement, text, this._editNode).then(changed => {
       if (!changed) {
         return original;


### PR DESCRIPTION
Fixes rename when the rename cell is no longer available.
Adds a soft selection, which is used for context menus and drops when a non-selected item is dragged or right-clicked.
